### PR TITLE
Fixed "Unexpected key StorageClass" error

### DIFF
--- a/lib/bin/dbRecord.js
+++ b/lib/bin/dbRecord.js
@@ -29,8 +29,7 @@ class DbRecord {
 
             let params = {
                 Bucket: this.S3Bucket,
-                Key: key,
-                StorageClass: 'STANDARD_IA'
+                Key: key
             };
 
             let req = change.event === 'REMOVE' ? 'deleteObject' : 'putObject';


### PR DESCRIPTION
// OLD VALUE CAUSING THIS ERROR IN INCREMENTAL BACKUP: 
            // [error] {"id":{"S":"********-****-****-****-************"}} | deleteObject s3://****/*** | Unexpected key 'StorageClass' found in params
            // let params = {
            //     Bucket: this.S3Bucket,
            //     Key: key,
            //     StorageClass: 'STANDARD_IA'
            // };

            // Removing StorageClass and it works
            let params = {
                Bucket: this.S3Bucket,
                Key: key
            };