### PR TITLE
Fix InvalidArgument: A version-id marker cannot be specified without a key marker

### DIFF
--- a/lib/bin/versionList.js
+++ b/lib/bin/versionList.js
@@ -53,6 +53,7 @@ class VersionList {
                     s3DataContents = s3DataContents.concat(contents.DeleteMarkers);
 
                     if (data.IsTruncated) {
+                        params.KeyMarker = contents.NextKeyMarker;
                         params.VersionIdMarker = contents.NextVersionIdMarker;
                         recursiveCall.call(this, params);
                     } else {


### PR DESCRIPTION
Fix recursive fetch call - missing next key marker. Missing `NextKeyMarker` for recursion

http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#listObjectVersions-property