### PR TITLE
Undo changes made in commit 448db76 (PR #20)

### DIFF
--- a/lib/bin/restoreDynamoDb.js
+++ b/lib/bin/restoreDynamoDb.js
@@ -15,9 +15,7 @@ class RestoreDynamoDb {
             .then(keys => {
                 let promises = [];
                 Object.keys(versionList).forEach((key, index) => {
-                    if ( (! versionList[key].DeletedMarker &&  versionList[key].IsLatest) ) {
-                        promises.push(this.processVersion(versionList[key], keys));
-                    }
+                    promises.push(this.processVersion(versionList[key], keys));
                 });
 
                 return Promise.all(promises);

--- a/lib/bin/versionList.js
+++ b/lib/bin/versionList.js
@@ -149,8 +149,7 @@ class VersionList {
                 newData[key] = {
                     Key: version.Key,
                     VersionId: version.VersionId,
-                    DeletedMarker: version.DeletedMarker,
-                    IsLatest: version.IsLatest
+                    DeletedMarker: version.DeletedMarker
                 };
             });
 


### PR DESCRIPTION
So I thought it best to just undo.

There are 2 things that PR #20 did and I don't think you want either of them.

1. It stopped sending deletes to DynamoDB. So `pushToDynamoDb` never gets into it's `else` block. Which stops you from restoring to the table you're backing up from because now a restore never can remove deleted records at the version you've selected.

2. It only restores the record if it's the latest version, skipping any data that has been changed in the future.

I can kinda see why you would want this, if you had a table purely for current live data snapshots that you're taking periodically. Like a staging database built of the current live version or something...

Unfortunately it completely ruins the purpose of the restore: disaster recovery.

Tomorrow when I'm back at work I might look at writing a couple tests around this but for now an undo seemed safest.